### PR TITLE
fix: avoid undefined array key warning in RefundProcessor::doOnSuccess

### DIFF
--- a/LyranetworkMonetico/src/Sdk/RefundProcessor.php
+++ b/LyranetworkMonetico/src/Sdk/RefundProcessor.php
@@ -82,7 +82,7 @@ class RefundProcessor implements Processor
 
             $transactionUuid = $operationResponse['detailedStatus'] === 'CANCELLED' ? $operationResponse['uuid'] : $operationResponse['transactionDetails']['parentTransactionUuid'];
             foreach ($order->getPayments() as $payment) {
-                if ($transactionUuid === $payment->getDetails()["monetico_trans_uuid"]) {
+                if ($transactionUuid === ($payment->getDetails()['monetico_trans_uuid'] ?? null)) {
                     $paymentToRefund = $payment;
                     break;
                 }


### PR DESCRIPTION
## Problem

In `RefundProcessor::doOnSuccess`, the loop iterates over **all** payments of the order and unconditionally reads the `monetico_trans_uuid` key from `getDetails()`:

```php
foreach ($order->getPayments() as $payment) {
    if ($transactionUuid === $payment->getDetails()["monetico_trans_uuid"]) {
```

An order can legitimately contain payments without this key (cancelled retry payments with empty details, payments from other gateways, anonymized payments, etc.). On PHP 8+ this triggers `Warning: Undefined array key "monetico_trans_uuid"`, which is converted to an `ErrorException` by Symfony's error handler — interrupting the loop before the matching Monetico payment can be found. As a result, the Sylius `Payment` state machine transition to `refunded` is never applied, even though the refund itself succeeded on Monetico's side, leaving the local payment record desynchronized.

## Fix

Use the null-coalescing operator to safely read the key:

```php
if ($transactionUuid === ($payment->getDetails()['monetico_trans_uuid'] ?? null)) {
```

Minimal, behavior-preserving change: payments without the key simply don't match and the loop continues.